### PR TITLE
Fix - Uncaught DOMException

### DIFF
--- a/js/bioep.js
+++ b/js/bioep.js
@@ -104,7 +104,7 @@ window.bioEp = {
 
 		// Insert it before other existing style
 		// elements so user CSS isn't overwritten
-		document.head.insertBefore(style, document.getElementsByTagName("style")[0]);
+		document.head.insertBefore(style, document.head.getElementsByTagName("style")[0]);
 	},
 
 	// Add the popup to the page


### PR DESCRIPTION
When in body exists style tag then we get Uncaught DOMException: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.
Fix - find elements only in head